### PR TITLE
Throw when container list does not exist.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ply",
-  "version": "0.2.9",
+  "version": "0.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@128technology/ply",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Manage model files that describe the GUI presentation of a Yinz data model.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {
   SectionPlugin
 } from './instance';
 
-import { KeyUndefinedError } from './instance/errors';
+import { KeyUndefinedError, ContainingListDoesNotExistError } from './instance/errors';
 import { IErrorLocation } from './validate/ErrorReporter';
 import { ErrorLevel } from './enum';
 import * as Plugins from './plugins';
@@ -40,6 +40,7 @@ export {
   ContainerField,
   ContainerFieldInstance,
   ContainerPlugin,
+  ContainingListDoesNotExistError,
   ErrorLevel,
   FieldInstance,
   IErrorLocation,

--- a/src/instance/SectionInstance.ts
+++ b/src/instance/SectionInstance.ts
@@ -8,7 +8,6 @@ import { FieldInstance, IParams } from './InstanceTypes';
 import { PresentationModelInstance, PageInstance, SectionPlugin } from './';
 import { Section, ChoiceField } from '../model';
 import { buildField } from './util';
-import { PathSegment } from '@128technology/yinz/dist/instance/Path';
 
 function getPath(id: string, params: IParams, model: DataModel): Path {
   const splitPath = id.split('.');
@@ -73,7 +72,7 @@ export default class SectionInstance implements Child, Pluggable {
         const searchPath = field instanceof ChoiceField ? _.initial(path) : path;
         let instanceData = null;
 
-        const noMatchHandler = (stopInstance: Instance, remaining: PathSegment[]) => {
+        const noMatchHandler = (stopInstance: Instance, remaining: Path) => {
           if (_.find(remaining, 'keys')) {
             throw new ContainingListDoesNotExist(
               `Tried to find field ${field.id} but its containing list does not exist`

--- a/src/instance/SectionInstance.ts
+++ b/src/instance/SectionInstance.ts
@@ -1,12 +1,14 @@
 import * as _ from 'lodash';
-import { DataModel, List, DataModelInstance, Path } from '@128technology/yinz';
+import { DataModel, List, DataModelInstance, Path, Instance } from '@128technology/yinz';
 
 import applyMixins from '../util/applyMixins';
+import ContainingListDoesNotExist from './errors/ContainingListDoesNotExistError';
 import { Child, Pluggable } from './mixins';
 import { FieldInstance, IParams } from './InstanceTypes';
 import { PresentationModelInstance, PageInstance, SectionPlugin } from './';
 import { Section, ChoiceField } from '../model';
 import { buildField } from './util';
+import { PathSegment } from '@128technology/yinz/dist/instance/Path';
 
 function getPath(id: string, params: IParams, model: DataModel): Path {
   const splitPath = id.split('.');
@@ -71,10 +73,22 @@ export default class SectionInstance implements Child, Pluggable {
         const searchPath = field instanceof ChoiceField ? _.initial(path) : path;
         let instanceData = null;
 
+        const noMatchHandler = (stopInstance: Instance, remaining: PathSegment[]) => {
+          if (_.find(remaining, 'keys')) {
+            throw new ContainingListDoesNotExist(
+              `Tried to find field ${field.id} but its containing list does not exist`
+            );
+          }
+        };
+
         try {
-          instanceData = instance.getInstance(searchPath);
+          instanceData = instance.getInstance(searchPath, noMatchHandler);
         } catch (e) {
           // Field has no data in the instance, this is okay. Continue on.
+          // Unless the field is in a list instance that does not exist.
+          if (e instanceof ContainingListDoesNotExist) {
+            throw e;
+          }
         }
 
         return { field, path, instanceData };

--- a/src/instance/errors/ContainingListDoesNotExistError.ts
+++ b/src/instance/errors/ContainingListDoesNotExistError.ts
@@ -1,0 +1,6 @@
+export default class ContainingListDoesNotExistError extends Error {
+  constructor(...args: any[]) {
+    super(...args);
+    Error.captureStackTrace(this, ContainingListDoesNotExistError);
+  }
+}

--- a/src/instance/errors/index.ts
+++ b/src/instance/errors/index.ts
@@ -1,1 +1,2 @@
 export { default as KeyUndefinedError } from './KeyUndefinedError';
+export { default as ContainingListDoesNotExistError } from './ContainingListDoesNotExistError';


### PR DESCRIPTION
Added logic to implement a noMatchHandler when attempting to retrieve instance data for a SectionInstance which will throw an error if the field's containing list does not exist.